### PR TITLE
Add Canary Islands travel guide

### DIFF
--- a/europe/README.md
+++ b/europe/README.md
@@ -1,1 +1,2 @@
 # EUROPE
+- [Spain](spain/README.md)

--- a/europe/spain/README.md
+++ b/europe/spain/README.md
@@ -1,0 +1,2 @@
+# spain
+- [Canary Islands](canary_islands.md)

--- a/europe/spain/canary_islands.md
+++ b/europe/spain/canary_islands.md
@@ -1,0 +1,5 @@
+# Canary Islands
+
+We would like to visit the Canary Islands because of their warm weather, beautiful beaches, and volcanic landscapes.
+
+More info at [wikivoyage](https://en.wikivoyage.org/wiki/Canary_Islands) and [wikipedia](https://en.wikipedia.org/wiki/Canary_Islands)


### PR DESCRIPTION
This PR adds a new travel guide for the Canary Islands, including links from Europe and Spain directories.

Partner: @szaaaaaa

Answers UCL-COMP0233-25-26/RSE-Classwork#3